### PR TITLE
Correção Issue#1 e alteração na escolha de arquivo

### DIFF
--- a/src/main/java/org/engmetrics/gui/StartWindow.java
+++ b/src/main/java/org/engmetrics/gui/StartWindow.java
@@ -3,11 +3,7 @@ package org.engmetrics.gui;
 
 import org.engmetrics.cli.TerminalProcess;
 import java.io.File;
-import java.io.IOException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.swing.JFileChooser;
-import javax.swing.filechooser.FileNameExtensionFilter;
 
 /**
  * The main project window class to interact with users

--- a/src/main/java/org/engmetrics/gui/StartWindow.java
+++ b/src/main/java/org/engmetrics/gui/StartWindow.java
@@ -3,7 +3,11 @@ package org.engmetrics.gui;
 
 import org.engmetrics.cli.TerminalProcess;
 import java.io.File;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.swing.JFileChooser;
+import javax.swing.filechooser.FileNameExtensionFilter;
 
 /**
  * The main project window class to interact with users
@@ -130,16 +134,18 @@ public class StartWindow extends javax.swing.JFrame {
     }// </editor-fold>//GEN-END:initComponents
 
     private void btnUploadActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnUploadActionPerformed
-        JFileChooser windowUpload = new JFileChooser();
-        windowUpload.setDialogTitle("Choose file");
-        windowUpload.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
-        
-        int userAnswer = windowUpload.showOpenDialog(this);
-        if (userAnswer == JFileChooser.APPROVE_OPTION){ //user selected something
-            this.selectedDirectory = windowUpload.getSelectedFile();
+       JFileChooser fc = new JFileChooser();
+        fc.setDialogType(JFileChooser.OPEN_DIALOG);
+        fc.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
+        File initialDir = new File("./");
+        fc.setCurrentDirectory(initialDir);
+        fc.setDialogTitle("Choose file");
+        int returnVal = fc.showOpenDialog(this);
+        if (returnVal == JFileChooser.APPROVE_OPTION) {
+            this.selectedDirectory = fc.getSelectedFile();
             this.txtLocation.setText(this.selectedDirectory.getAbsolutePath());
             this.txtResults.setText("Folder selected, click on Start Analysis (click and wait).");
-        }
+        } 
     }//GEN-LAST:event_btnUploadActionPerformed
 
     /**
@@ -152,7 +158,8 @@ public class StartWindow extends javax.swing.JFrame {
             this.txtResults.setText("You need to set a source code path to run this analysis \n");
         
         }else{
-            TerminalProcess terminal = new TerminalProcess("java -jar", "tools/checkstyle.jar", "tools/config.xml", this.txtLocation.getText());
+            String formatPath = "\"" + this.txtLocation.getText() + "\"";
+            TerminalProcess terminal = new TerminalProcess("java -jar", "tools/checkstyle.jar", "tools/config.xml", formatPath);
             boolean success = terminal.runCommand();
             if(success){
                 this.txtResults.setText(this.txtResults.getText() + terminal.getOutputText());


### PR DESCRIPTION
## Implementações
- Alteração na forma de escolha de arquivo:
  - Ao clica na opção "Click here to choose a source code path..." agora a janela de escolha de diretório abre onde se encontra o executável da aplicação para então escolher qual diretório será analisado.
## Correções
- Corrigida a falha relatada na Issue#1:
  - Ao clicar no botão de iniciar análise, o sistema processa estruturas de diretórios separados por espaços em branco corretamente;
  - A causa do problema foi a forma como a string do caminho estava sendo tratada;
  - A estratégia de correção utilizada foi colocar o caminho entre aspas duplas (" ") para que ele seja interpretado como um único argumento pela função que está sendo usada para manipulá-lo;
  - Isso faz com que o comando shell interprete o caminho entre aspas duplas como um único argumento, mesmo que ele contenha espaços;
  - Nessa situação, deve-se colocar o caminho entre aspas duplas para que ele seja interpretados corretamente.
- Teste Issue#1:

![Teste_Issue#1](https://user-images.githubusercontent.com/97888901/232642925-740c4827-4acb-45ba-bf56-750dfba7ffca.png)
